### PR TITLE
Fixing bug on Close() when far end isn't listening, plus features.

### DIFF
--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -29,7 +29,7 @@ func TestSend(t *testing.T) {
 		{
 			name: "Error: client closed",
 			client: &Client{
-				sendRunner: func(ctx context.Context, msg msgs.Msg) error {
+				sendRunner: func(ctx context.Context, msg msgs.Msg, options ...base.SendOption) error {
 					return nil
 				},
 			},
@@ -39,7 +39,7 @@ func TestSend(t *testing.T) {
 		{
 			name: "Error: IsUnrecoverable()",
 			client: &Client{
-				sendRunner: func(ctx context.Context, msg msgs.Msg) error {
+				sendRunner: func(ctx context.Context, msg msgs.Msg, options ...base.SendOption) error {
 					return base.ErrConnection
 				},
 				replaceBackoffRunner: func(ctx context.Context) error {
@@ -52,7 +52,7 @@ func TestSend(t *testing.T) {
 		{
 			name: "Error: IsQueueFull()",
 			client: &Client{
-				sendRunner: func(ctx context.Context, msg msgs.Msg) error {
+				sendRunner: func(ctx context.Context, msg msgs.Msg, options ...base.SendOption) error {
 					return base.ErrQueueFull
 				},
 				notifier: make(chan NotifyError, 1),
@@ -63,7 +63,7 @@ func TestSend(t *testing.T) {
 		{
 			name: "Error: IsValidationErr()",
 			client: &Client{
-				sendRunner: func(ctx context.Context, msg msgs.Msg) error {
+				sendRunner: func(ctx context.Context, msg msgs.Msg, options ...base.SendOption) error {
 					return base.ErrValidation
 				},
 			},
@@ -72,7 +72,7 @@ func TestSend(t *testing.T) {
 		{
 			name: "Error: error is uncategorized",
 			client: &Client{
-				sendRunner: func(ctx context.Context, msg msgs.Msg) error {
+				sendRunner: func(ctx context.Context, msg msgs.Msg, options ...base.SendOption) error {
 					return errors.New("error")
 				},
 			},
@@ -81,7 +81,7 @@ func TestSend(t *testing.T) {
 		{
 			name: "Success",
 			client: &Client{
-				sendRunner: func(ctx context.Context, msg msgs.Msg) error {
+				sendRunner: func(ctx context.Context, msg msgs.Msg, options ...base.SendOption) error {
 					return nil
 				},
 			},

--- a/audit/base/base_test.go
+++ b/audit/base/base_test.go
@@ -281,6 +281,32 @@ func TestSend(t *testing.T) {
 	}
 }
 
+func TestSendWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	msg := msgs.Msg{
+		Type:   msgs.DataPlane,
+		Record: validRecord.Clone(),
+	}
+	client := &Client{}
+
+	// Fill the send queue.
+	client.sendCh = make(chan SendMsg, 1)
+	client.sendCh <- SendMsg{Ctx: context.Background(), Msg: msg}
+
+	// Pull off a message after a second.
+	go func() {
+		time.Sleep(1 * time.Second)
+		<-client.sendCh
+	}()
+
+	// Call the Send() method with the specified record and context.
+	err := client.Send(context.Background(), msg, WithTimeout(3*time.Second))
+	if err != nil {
+		t.Errorf("Expected no error, but got error: %v", err)
+	}
+}
+
 func TestReset(t *testing.T) {
 	t.Parallel()
 

--- a/audit/internal/regressions/regression_test.go
+++ b/audit/internal/regressions/regression_test.go
@@ -1,0 +1,90 @@
+package regression
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gostdlib/concurrency/prim/wait"
+	"github.com/microsoft/go-otel-audit/audit"
+	"github.com/microsoft/go-otel-audit/audit/base"
+	"github.com/microsoft/go-otel-audit/audit/conn"
+	"github.com/microsoft/go-otel-audit/audit/msgs"
+)
+
+func TestNonListeningMDSDCausesCloseToBlockForever(t *testing.T) {
+	t.Parallel()
+
+	const auditLogQueueSize = 4000
+
+	var validRecord = msgs.Record{
+		CallerIpAddress:            msgs.MustParseAddr("192.168.0.1"),
+		CallerIdentities:           map[msgs.CallerIdentityType][]msgs.CallerIdentityEntry{msgs.UPN: {{"user1@domain.com", "Description"}}},
+		OperationCategories:        []msgs.OperationCategory{msgs.UserManagement},
+		TargetResources:            map[string][]msgs.TargetResourceEntry{"ResourceType": {{"Name", "Cluster", "DataCenter", "Region"}}},
+		CallerAccessLevels:         []string{"Level1"},
+		OperationAccessLevel:       "AccessLevel",
+		OperationName:              "Operation",
+		OperationResultDescription: "ResultDescription",
+		CallerAgent:                "Agent",
+	}
+
+	id := uuid.New().String()
+	socketName := fmt.Sprintf("/tmp/mysocket-%s.sock", id)
+	defer os.Remove(socketName)
+
+	// Create a Unix domain socket and listen for incoming connections.
+	// However, for this, we are not going to listen at all.
+	socket, err := net.Listen("unix", socketName)
+	if err != nil {
+		panic(err)
+	}
+	defer socket.Close()
+
+	// Create a function that will create a new connection to the remote audit server.
+	// We use this function to create a new connection when the connection is broken.
+	cc := func() (conn.Audit, error) {
+		return conn.NewDomainSocket(conn.DSPath(socketName))
+	}
+
+	// Creates the smart client to the remote audit server.
+	// You should only create one of these, preferrably in main().
+	c, err := audit.New(cc, audit.WithAuditOptions(base.WithSettings(base.Settings{QueueSize: auditLogQueueSize})))
+	if err != nil {
+		panic(err)
+	}
+	defer c.Close(context.Background())
+
+	// This is optional if you want to get notifications of logging problems or do something
+	// with messages that are not sent.
+	/*
+		go func() {
+			for notifyMsg := range c.Notify() {
+				log.Println(notifyMsg)
+			}
+		}()
+	*/
+
+	ctx := context.Background()
+	g := wait.Group{}
+	for i := 0; i < 10; i++ {
+		g.Go(
+			ctx,
+			func(ctx context.Context) error {
+				for i := 0; i < 1000; i++ {
+					// Send a message to the remote audit server.
+					if err := c.Send(context.Background(), msgs.Msg{Type: msgs.ControlPlane, Record: validRecord}); err != nil {
+						log.Printf("msg(%d): %s}", i, err)
+					}
+				}
+				return nil
+			},
+		)
+	}
+
+	g.Wait(ctx)
+}

--- a/audit/internal/scenarios/scenarios_test.go
+++ b/audit/internal/scenarios/scenarios_test.go
@@ -1,0 +1,106 @@
+package scenarios
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/microsoft/go-otel-audit/audit"
+	"github.com/microsoft/go-otel-audit/audit/base"
+	"github.com/microsoft/go-otel-audit/audit/conn"
+	"github.com/microsoft/go-otel-audit/audit/msgs"
+)
+
+func TestSlowListeningMDSD(t *testing.T) {
+	t.Parallel()
+
+	const auditLogQueueSize = 1
+
+	var validRecord = msgs.Record{
+		CallerIpAddress:            msgs.MustParseAddr("192.168.0.1"),
+		CallerIdentities:           map[msgs.CallerIdentityType][]msgs.CallerIdentityEntry{msgs.UPN: {{"user1@domain.com", "Description"}}},
+		OperationCategories:        []msgs.OperationCategory{msgs.UserManagement},
+		TargetResources:            map[string][]msgs.TargetResourceEntry{"ResourceType": {{"Name", "Cluster", "DataCenter", "Region"}}},
+		CallerAccessLevels:         []string{"Level1"},
+		OperationAccessLevel:       "AccessLevel",
+		OperationName:              "Operation",
+		OperationResultDescription: "ResultDescription",
+		CallerAgent:                "Agent",
+	}
+
+	id := uuid.New().String()
+	socketName := fmt.Sprintf("/tmp/mysocket-%s.sock", id)
+	defer os.Remove(socketName)
+
+	// Create a Unix domain socket and listen for incoming connections.
+	// However, for this, we are not going to listen at all.
+	socket, err := net.Listen("unix", socketName)
+	if err != nil {
+		panic(err)
+	}
+	defer socket.Close()
+
+	// Create a function that will create a new connection to the remote audit server.
+	// We use this function to create a new connection when the connection is broken.
+	cc := func() (conn.Audit, error) {
+		return conn.NewDomainSocket(conn.DSPath(socketName))
+	}
+
+	// Creates the smart client to the remote audit server.
+	// You should only create one of these, preferrably in main().
+	c, err := audit.New(cc, audit.WithAuditOptions(base.WithSettings(base.Settings{QueueSize: auditLogQueueSize})))
+	if err != nil {
+		panic(err)
+	}
+	//defer c.Close(context.Background())
+
+	go func() {
+		c, err := socket.Accept()
+		if err != nil {
+			panic(err)
+		}
+
+		b := make([]byte, 1024)
+		for {
+			c.Read(b)
+			time.Sleep(500 * time.Millisecond)
+		}
+	}()
+
+	for i := 0; i < 10000; i++ {
+		// Send a message to the remote audit server.
+		if err := c.Send(context.Background(), msgs.Msg{Type: msgs.ControlPlane, Record: validRecord}); err != nil {
+			log.Printf("msg(%d): %s}", i, err)
+		}
+	}
+
+	log.Println("Done")
+
+	time.Sleep(2 * time.Second)
+}
+
+func TestNonExistingSocket(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New().String()
+	socketName := fmt.Sprintf("/tmp/mysocket-%s.sock", id)
+
+	// Create a function that will create a new connection to the remote audit server.
+	// We use this function to create a new connection when the connection is broken.
+	cc := func() (conn.Audit, error) {
+		return conn.NewDomainSocket(conn.DSPath(socketName))
+	}
+
+	// Creates the smart client to the remote audit server.
+	// You should only create one of these, preferrably in main().
+	_, err := audit.New(cc)
+	if err != nil {
+		return
+	}
+	t.Fatalf("TestNonExistingSocket: expected error, got nil")
+}


### PR DESCRIPTION
Close() would block indefinitely if mdsd wasn't listening, this gives a default timeout.

Added WithTimeout() for Send(). This allows for some non-blocking behavior without getting confused with a Context timeout.

Added some tests for various scenarios to ensure we have them covered.