### PR TITLE
Fixing issue: https://github.com/microsoft/go-otel-audit/issues/15

### DIFF
--- a/audit/base/base.go
+++ b/audit/base/base.go
@@ -63,6 +63,9 @@ import (
 	"github.com/microsoft/go-otel-audit/audit/conn"
 	"github.com/microsoft/go-otel-audit/audit/internal/version"
 	"github.com/microsoft/go-otel-audit/audit/msgs"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // ctxBack is used as a background context when we cannot use a context passed
@@ -96,6 +99,26 @@ func IsUnrecoverable(err error) bool {
 		return true
 	}
 	return false
+}
+
+type metrics struct {
+	meter        metric.Meter
+	msgsSent     metric.Int64Counter
+	msgsRequeued metric.Int64Counter
+	msgsDropped  metric.Int64Counter
+	msgErrs      metric.Int64Counter
+
+	// requeuedCounter exists to track the number of requeued messages in a test.
+	// You cannot extract the value from an otel counter.
+	requeuedCounter atomic.Uint64
+}
+
+func (m *metrics) init() {
+	m.meter = otel.GetMeterProvider().Meter("github.com/microsoft/go-otel-audit/audit/base")
+	m.msgsSent, _ = m.meter.Int64Counter("messages_sent")
+	m.msgsRequeued, _ = m.meter.Int64Counter("messages_requeed")
+	m.msgsDropped, _ = m.meter.Int64Counter("messages_dropped")
+	m.msgErrs, _ = m.meter.Int64Counter("messages_errors")
 }
 
 // Client represents a client connection to an audit server.
@@ -138,6 +161,8 @@ type Client struct {
 	// heartbeatInterval is the interval for sending heartbeats. A value of
 	// 0 means no heartbeats are sent.
 	heartbeatInterval time.Duration
+
+	metrics *metrics
 }
 
 // Settings represents the settings for the audit client. These are used to configure how the
@@ -188,10 +213,14 @@ func New(c conn.Audit, options ...Option) (client *Client, err error) {
 		return nil, fmt.Errorf("cannot pass a conn.Audit that is nil: %w", ErrConnection)
 	}
 
+	m := &metrics{}
+	m.init()
+
 	cli := &Client{
 		settings:          Settings{}.defaults(),
 		log:               slog.Default(),
 		heartbeatInterval: 30 * time.Minute,
+		metrics:           m,
 	}
 	cli.conn.Store(&c)
 
@@ -338,6 +367,9 @@ func (c *Client) Send(ctx context.Context, msg msgs.Msg, options ...SendOption) 
 		defer timer.Stop()
 		select {
 		case <-timer.C:
+			if c.conn.Load() == nil {
+				return ErrConnection
+			}
 			return ErrQueueFull
 		case c.sendCh <- SendMsg{Ctx: ctx, Msg: msg}:
 		}
@@ -347,6 +379,9 @@ func (c *Client) Send(ctx context.Context, msg msgs.Msg, options ...SendOption) 
 		select {
 		case c.sendCh <- SendMsg{Ctx: ctx, Msg: msg}:
 		default:
+			if c.conn.Load() == nil {
+				return ErrConnection
+			}
 			return ErrQueueFull
 		}
 	}
@@ -373,7 +408,6 @@ func (c *Client) Reset(ctx context.Context, newConn conn.Audit) error {
 	// If for some reason there is no error happening, we need to set one to prevents sends.
 
 	c.setErr(fmt.Errorf("audit client Reset() called, resetting connection: %w", ErrConnection))
-
 	// If the connection is live, we need to close it.
 	c.close(ctx, false)
 	c.conn.Store(&newConn)
@@ -470,38 +504,48 @@ func (c *Client) sender() {
 	var tickerCh <-chan time.Time
 
 	for {
+		// If the connection is nil, we need to wait for it to be set and not
+		// drain the message queue.
+		conn := c.conn.Load()
+		if conn == nil {
+			time.Sleep(1 * time.Second)
+			select {
+			case sig := <-c.stopSend:
+				// Let the other side know we are done.
+				sig <- struct{}{}
+				return
+			default:
+			}
+			continue
+		}
+
+		// This happens after we send the first message before we start the ticker.
 		if c.successSend && ticker == nil {
-			c.write(ctxBack, c.heartbeat)
+			c.write(ctxBack, c.heartbeat, conn)
 			ticker = time.NewTicker(c.heartbeatInterval)
 			tickerCh = ticker.C
 		}
 
+		// The connection is fine, we can send messages.
 		select {
 		case sig := <-c.stopSend:
 			// Let the other side know we are done.
 			sig <- struct{}{}
 			return
 		case sm := <-c.sendCh:
-			c.write(sm.Ctx, sm.Msg)
+			c.write(sm.Ctx, sm.Msg, conn)
 		case <-tickerCh:
-			c.write(ctxBack, c.heartbeat)
+			c.write(ctxBack, c.heartbeat, conn)
 		}
 	}
 }
 
-func (c *Client) write(ctx context.Context, msg msgs.Msg) {
-	ptr := c.conn.Load()
-	if ptr == nil {
-		return
-	}
-
-	if err := (*ptr).Write(ctx, msg); err != nil {
-		// Requeue the message if we can.
-		select {
-		case c.sendCh <- SendMsg{Ctx: ctx, Msg: msg}:
-		default:
-			c.log.Error(fmt.Sprintf("audit message dropped due to queue being full: %v", err))
-		}
+// write writes the message to the audit server. If the write fails, the message is requeued if there
+// is room. If there is no room, the message is dropped. Dropped messages are noted in logs.
+func (c *Client) write(ctx context.Context, msg msgs.Msg, conn *conn.Audit) {
+	if err := (*conn).Write(ctx, msg); err != nil {
+		c.metrics.msgErrs.Add(ctx, 1)
+		c.msgRequeueOrDrop(ctx, msg, err)
 
 		if err == context.Canceled {
 			c.log.Error(fmt.Sprintf("audit message had context cancellation: %s", err))
@@ -510,7 +554,20 @@ func (c *Client) write(ctx context.Context, msg msgs.Msg) {
 		c.setErr(fmt.Errorf("%w: %w", err, ErrConnection))
 		return
 	}
+	c.metrics.msgsSent.Add(ctx, 1)
 	c.successSend = true
+}
+
+// msgRequeueOrDrop requeues the message if there is room in the queue. If there is no room, the message is dropped.
+func (c *Client) msgRequeueOrDrop(ctx context.Context, msg msgs.Msg, err error) {
+	select {
+	case c.sendCh <- SendMsg{Ctx: ctx, Msg: msg}:
+		c.metrics.requeuedCounter.Add(1)
+		c.metrics.msgsRequeued.Add(ctx, 1)
+	default:
+		c.metrics.msgsDropped.Add(ctx, 1)
+		c.log.Error(fmt.Sprintf("audit message dropped due to queue being full: %v", err))
+	}
 }
 
 // setErr sets the error for the client if the error is not already set. If the error being set it nil,
@@ -519,13 +576,19 @@ func (c *Client) setErr(err error) {
 	c.setErrMu.Lock()
 	defer c.setErrMu.Unlock()
 
+	// This resets the error if the error passed is nil.
 	if err == nil {
 		c.err.Store(nil)
+		return
 	}
 
+	// If there already is an error, we don't need to overwrite it.
 	if c.err.Load() != nil {
 		return
 	}
+
+	// This sets the conn to nil. This prevents any further writes to the connection until it gets replaced.
+	c.conn.Store(nil)
 
 	c.err.Store(&err)
 }

--- a/audit/base/base_test.go
+++ b/audit/base/base_test.go
@@ -252,10 +252,7 @@ func TestSend(t *testing.T) {
 			test.ctx = context.Background()
 		}
 
-		m := &metrics{}
-		m.init()
-
-		client := &Client{metrics: m}
+		client := &Client{metrics: newMetrics()}
 		client.sendCh = test.sendCh
 
 		// Note: for the QueueFull test, we need to fill the send channel to force the select
@@ -292,9 +289,7 @@ func TestSendWithTimeout(t *testing.T) {
 		Type:   msgs.DataPlane,
 		Record: validRecord.Clone(),
 	}
-	m := &metrics{}
-	m.init()
-	client := &Client{metrics: m}
+	client := &Client{metrics: newMetrics()}
 
 	// Fill the send queue.
 	client.sendCh = make(chan SendMsg, 1)
@@ -335,18 +330,16 @@ func TestReset(t *testing.T) {
 		newConn conn.Audit
 		err     bool
 	}{
-		/*
-			{
-				name:    "Nil client",
-				newConn: conn.NewNoOP(),
-				err:     true,
-			},
-			{
-				name:   "Nil connection",
-				client: must(),
-				err:    true,
-			},
-		*/
+		{
+			name:    "Nil client",
+			newConn: conn.NewNoOP(),
+			err:     true,
+		},
+		{
+			name:   "Nil connection",
+			client: must(),
+			err:    true,
+		},
 		{
 			name:    "Valid reset",
 			client:  must(),

--- a/audit/base/regression_test.go
+++ b/audit/base/regression_test.go
@@ -1,0 +1,53 @@
+package base
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/microsoft/go-otel-audit/audit/conn"
+	"github.com/microsoft/go-otel-audit/audit/msgs"
+)
+
+type badConn struct {
+	conn.Audit
+}
+
+func (b *badConn) Write(context.Context, msgs.Msg) error {
+	return errors.New("error")
+}
+
+// https://github.com/microsoft/go-otel-audit/issues/15
+// Basically, this is when we have more buffer than issues coming in, the far side stops
+// processing the messages and we requeue them until the buffer is full, which never occurs.
+func TestTimeoutCausesRetryLoop(t *testing.T) {
+	t.Parallel()
+
+	m := &metrics{}
+	m.init()
+
+	c := &Client{
+		stopSend: make(chan chan struct{}),
+		sendCh:   make(chan SendMsg, 1),
+		metrics:  m,
+	}
+	var i conn.Audit = &badConn{}
+	c.conn.Store(&i)
+
+	go c.sender()
+
+	c.sendCh <- SendMsg{
+		Ctx: context.Background(),
+		Msg: msgs.Msg{
+			Type:   msgs.DataPlane,
+			Record: validRecord.Clone(),
+		},
+	}
+
+	time.Sleep(2 * time.Second)
+
+	if c.metrics.requeuedCounter.Load() > 1 {
+		t.Fatalf("TestTimeoutCausesRetryLoop: requeuedCounter should not have been incremented more than once")
+	}
+}

--- a/audit/base/regression_test.go
+++ b/audit/base/regression_test.go
@@ -18,19 +18,20 @@ func (b *badConn) Write(context.Context, msgs.Msg) error {
 	return errors.New("error")
 }
 
+func (b *badConn) CloseSend(ctx context.Context) error {
+	return nil
+}
+
 // https://github.com/microsoft/go-otel-audit/issues/15
 // Basically, this is when we have more buffer than issues coming in, the far side stops
 // processing the messages and we requeue them until the buffer is full, which never occurs.
 func TestTimeoutCausesRetryLoop(t *testing.T) {
 	t.Parallel()
 
-	m := &metrics{}
-	m.init()
-
 	c := &Client{
 		stopSend: make(chan chan struct{}),
 		sendCh:   make(chan SendMsg, 1),
-		metrics:  m,
+		metrics:  newMetrics(),
 	}
 	var i conn.Audit = &badConn{}
 	c.conn.Store(&i)

--- a/audit/internal/regressions/regression_test.go
+++ b/audit/internal/regressions/regression_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/microsoft/go-otel-audit/audit/msgs"
 )
 
+// TestNonListeningMDSDCausesCloseToBlockForever was a bug found where Close() never closed due to waiting for the queue
+// to empty. If the listener isn't working, this never happens.
+// This test takes some time (around 20 seconds), because it has to hit a timeout that isn't worth faking.
 func TestNonListeningMDSDCausesCloseToBlockForever(t *testing.T) {
 	t.Parallel()
 

--- a/go.mod
+++ b/go.mod
@@ -11,17 +11,20 @@ require (
 	github.com/kylelemons/godebug v1.1.0
 	github.com/stretchr/testify v1.8.4
 	github.com/vmihailenco/msgpack/v4 v4.3.13
+	go.opentelemetry.io/otel v1.24.0
+	go.opentelemetry.io/otel/metric v1.24.0
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
 	golang.org/x/sys v0.23.0
 )
 
 require (
+	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gostdlib/internals v0.0.0-20240319155855-57c259c0554f // indirect
 	github.com/jedib0t/go-pretty/v6 v6.5.6 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
-	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,11 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-json-experiment/json v0.0.0-20240418180308-af2d5061e6c2 h1:lhCu2IkNoFfDdcjHos2ZtLdAsyxLZbkpijNzhvvM6BY=
 github.com/go-json-experiment/json v0.0.0-20240418180308-af2d5061e6c2/go.mod h1:6daplAwHHGbUGib4990V3Il26O0OC4aRyvewaaAihaA=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -45,6 +50,8 @@ github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37w
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 go.opentelemetry.io/otel v1.24.0 h1:0LAOdjNmQeSTzGBzduGe/rU4tZhMwL5rWgtp9Ku5Jfo=
 go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi/MArHo=
+go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGXlc88kI=
+go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y1YELI=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
This adds a regression for the issue and corrects the issue so that we don't end up with 100% cpu usage on clients that rarely get audit messages.

This is most likely to affect TCP connections and not domain socket due to the nature of a local connection vs a connection over a network.

However, users should upgrade to fix the issue.