### PR TITLE
Require service tree ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cc := func() (conn.Audit, error) {
 
 // Creates the smart client to the remote audit server.
 // You should only create one of these, preferrably in main().
-c, err := audit.New(cc)
+c, err := audit.New(ctx, serviceTreeID, cc)
 if err != nil {
 	// Handle error.
 }

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -17,7 +17,7 @@ Example using the domainsocket package:
 
 	// Creates the smart client to the remote audit server.
 	// You should only create one of these, preferrably in main().
-	c, err := audit.New(ctx, cc)
+	c, err := audit.New(ctx, serviceTreeID, cc)
 	if err != nil {
 		// Handle error.
 	}
@@ -53,6 +53,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gostdlib/base/concurrency/sync"
 	"github.com/gostdlib/base/context"
 	"github.com/microsoft/go-otel-audit/audit/conn"
@@ -91,6 +92,8 @@ type NotifyError struct {
 // Client is an audit server smart client. This handles any connection problems silently, while providing ways to
 // detect problems through whatever alerting method is desired.
 type Client struct {
+	// serviceTreeID is a Microsoft GUID representing a value in the service tree service.
+	serviceTreeID string
 	// kver is the kernel version of the host
 	kver string
 	// goos is the operating system of the host. This is set to runtime.GOOS.
@@ -167,7 +170,10 @@ func WithLogger(l *slog.Logger) Option {
 // New creates a new smart client to the remote audit server. You can get a CreateConn
 // from conn.NewDomainSocket(), conn.NewTCP() or conn.NewNoop(). The last one is useful for testing
 // when you don't want to send logs anywhere.
-func New(ctx context.Context, create CreateConn, options ...Option) (*Client, error) {
+func New(ctx context.Context, serviceTreeID uuid.UUID, create CreateConn, options ...Option) (*Client, error) {
+	if serviceTreeID == uuid.Nil {
+		return nil, fmt.Errorf("serviceTreeID cannot be nil: %w", ErrValidation)
+	}
 	kver, err := kernelVer()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine kernel version on platform: %w", err)
@@ -186,6 +192,7 @@ func New(ctx context.Context, create CreateConn, options ...Option) (*Client, er
 	}
 
 	c := &Client{
+		serviceTreeID:       serviceTreeID.String(),
 		kver:                kver,
 		goos:                runtime.GOOS,
 		queueSize:           DefaultQueueSize,
@@ -311,10 +318,11 @@ func (c *Client) newSender() (msgSenderer, error) {
 	hb := msgs.Msg{
 		Type: msgs.Heartbeat,
 		Heartbeat: msgs.HeartbeatMsg{
-			AuditVersion: version.Semantic,
-			OsVersion:    c.kver,
-			Language:     runtime.Version(),
-			Destination:  auditConn.Type().String(),
+			ServiceTreeID: c.serviceTreeID,
+			AuditVersion:  version.Semantic,
+			OsVersion:     c.kver,
+			Language:      runtime.Version(),
+			Destination:   auditConn.Type().String(),
 		},
 	}
 
@@ -357,6 +365,10 @@ func (c *Client) Send(ctx context.Context, msg msgs.Msg, options ...SendOption) 
 	// like a heartbeat.
 	if msg.Type == msgs.ATUnknown || msg.Type > msgs.ControlPlane {
 		return fmt.Errorf("audit type (%v) is invalid: %w", msg.Type, ErrValidation)
+	}
+	switch msg.Type {
+	case msgs.ControlPlane, msgs.DataPlane:
+		msg.Record.ServiceTreeID = c.serviceTreeID
 	}
 
 	if err := msg.Record.Validate(); err != nil {

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -281,10 +281,13 @@ func TestNewSender(t *testing.T) {
 		},
 	}
 
+	const testServiceTreeID = "e6c9fcb1-7f08-4c1d-9e7a-123456789abc"
+
 	for _, test := range tests {
 		client := &Client{
-			kver: "test-kernel",
-			goos: test.goos,
+			serviceTreeID: testServiceTreeID,
+			kver:          "test-kernel",
+			goos:          test.goos,
 			create: func() (conn.Audit, error) {
 				if test.createErr != nil {
 					return nil, test.createErr
@@ -327,10 +330,11 @@ func TestNewSender(t *testing.T) {
 		}
 
 		wantHB := msgs.HeartbeatMsg{
-			AuditVersion: version.Semantic,
-			OsVersion:    client.kver,
-			Language:     runtime.Version(),
-			Destination:  test.connType.String(),
+			ServiceTreeID: testServiceTreeID,
+			AuditVersion:  version.Semantic,
+			OsVersion:     client.kver,
+			Language:      runtime.Version(),
+			Destination:   test.connType.String(),
 		}
 
 		s := sender.(*msgSender)

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -76,7 +76,10 @@ func TestSend(t *testing.T) {
 			test.ctx = context.Background()
 		}
 
-		client := &Client{metrics: mustNewMetrics()}
+		client := &Client{
+			serviceTreeID: "e6c9fcb1-7f08-4c1d-9e7a-123456789abc",
+			metrics:       mustNewMetrics(),
+		}
 		client.sendCh = test.sendCh
 
 		err := client.Send(test.ctx, test.msg)

--- a/audit/internal/scenarios/scenarios_test.go
+++ b/audit/internal/scenarios/scenarios_test.go
@@ -52,7 +52,7 @@ func TestSlowListeningMDSD(t *testing.T) {
 
 	// Creates the smart client to the remote audit server.
 	// You should only create one of these, preferrably in main().
-	c, err := audit.New(t.Context(), cc, audit.WithQueueSize(auditLogQueueSize))
+	c, err := audit.New(t.Context(), uuid.New(), cc, audit.WithQueueSize(auditLogQueueSize))
 	if err != nil {
 		panic(err)
 	}
@@ -92,7 +92,7 @@ func TestNonExistingSocket(t *testing.T) {
 
 	// Creates the smart client to the remote audit server.
 	// You should only create one of these, preferrably in main().
-	_, err := audit.New(t.Context(), cc)
+	_, err := audit.New(t.Context(), uuid.New(), cc)
 	if err != nil {
 		return
 	}

--- a/audit/msgs/heatbeat.go
+++ b/audit/msgs/heatbeat.go
@@ -3,6 +3,8 @@ package msgs
 // HeartbeatMsg is a message sent to the audit server with various endpoint information.
 // This is sent periodically by the client and does not require a user to send it.
 type HeartbeatMsg struct {
+	// ServiceTreeID is the GUID of the service in service tree.
+	ServiceTreeID string `msgpack:"AsmAuditServiceId" json:"AsmAuditServiceId"`
 	// AuditVersion is the version of the audit client.
 	AuditVersion string
 	// OsVersion is the version of the operating system.

--- a/audit/msgs/msgs.go
+++ b/audit/msgs/msgs.go
@@ -517,6 +517,8 @@ func (t TargetResourceEntry) Validate() error {
 type Record struct {
 	now func() time.Time `msgpack:"-" json:"-"`
 
+	// ServiceTreeID is the ID in service tree this belongs to. On the wire, this is env_ikey.
+	ServiceTreeID string `msgpack:"env_ikey" json:"env_ikey"`
 	// CallerIpAddress is the IP address of the caller.
 	CallerIpAddress Addr
 	// CallerIdentities is the identities that initiated the operation.
@@ -591,6 +593,9 @@ func (a Record) Validate() (err error) {
 	// If the server doesn't do any validation, then it should be fixed there if this is a problem.
 	// Because anyone can just write to the security endpoint.
 
+	if a.ServiceTreeID == "" {
+		return fmt.Errorf("service tree ID is required")
+	}
 	if a.OperationName == "" {
 		return fmt.Errorf("operation name is required")
 	}

--- a/audit/msgs/msgs_test.go
+++ b/audit/msgs/msgs_test.go
@@ -358,11 +358,18 @@ func TestJSONMarshalUnmarshal(t *testing.T) {
 }
 
 func TestRecordValidate(t *testing.T) {
+	const stID = "e6c9fcb1-7f08-4c1d-9e7a-123456789abc"
+
 	testCases := []struct {
 		name           string
 		auditRecord    Record
 		expectedResult error
 	}{
+		{
+			name:           "Missing ServiceTreeID",
+			auditRecord:    Record{},
+			expectedResult: fmt.Errorf("service tree ID is required"),
+		},
 		{
 			name:        "Missing OperationName",
 			auditRecord: Record{
@@ -614,6 +621,13 @@ func TestRecordValidate(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			// Every case except the dedicated "Missing ServiceTreeID" case needs a
+			// ServiceTreeID set so the new first-line check in Validate doesn't mask
+			// the field-specific error the case is trying to exercise.
+			if test.name != "Missing ServiceTreeID" {
+				test.auditRecord.ServiceTreeID = stID
+			}
+
 			err := test.auditRecord.Validate()
 			switch {
 			case err == nil && test.expectedResult != nil:
@@ -751,4 +765,100 @@ func TestBytesToStr(t *testing.T) {
 	b := []byte("Update")
 	s := bytesToStr(b)
 	assert.Equal(t, "Update", s)
+}
+
+// TestMarshalMsgpackWireKeys exercises the real wire encoding through
+// MarshalMsgpack and decodes the bytes back so struct-tag typos cannot slip
+// through. The outer envelope produced by marshalPrep looks like:
+//
+//	[type_string, [[timestamp, body]], {TimeFormat: "DateTime"}]
+//
+// where body is the serialized Record or HeartbeatMsg as a map.
+func TestMarshalMsgpackWireKeys(t *testing.T) {
+	t.Parallel()
+
+	n := func() time.Time { return time.Unix(1234, 0) }
+
+	const stID = "e6c9fcb1-7f08-4c1d-9e7a-123456789abc"
+
+	tests := []struct {
+		name      string
+		msg       Msg
+		wireKey   string
+		wireValue string
+	}{
+		{
+			name: "Success: DataPlane Record marshals ServiceTreeID as env_ikey",
+			msg: Msg{
+				now:    n,
+				Type:   DataPlane,
+				Record: Record{ServiceTreeID: stID},
+			},
+			wireKey:   "env_ikey",
+			wireValue: stID,
+		},
+		{
+			name: "Success: ControlPlane Record marshals ServiceTreeID as env_ikey",
+			msg: Msg{
+				now:    n,
+				Type:   ControlPlane,
+				Record: Record{ServiceTreeID: stID},
+			},
+			wireKey:   "env_ikey",
+			wireValue: stID,
+		},
+		{
+			name: "Success: Heartbeat marshals ServiceTreeID as AsmAuditServiceId",
+			msg: Msg{
+				now:       n,
+				Type:      Heartbeat,
+				Heartbeat: HeartbeatMsg{ServiceTreeID: stID},
+			},
+			wireKey:   "AsmAuditServiceId",
+			wireValue: stID,
+		},
+	}
+
+	for _, test := range tests {
+		data, err := MarshalMsgpack(test.msg)
+		if err != nil {
+			t.Errorf("TestMarshalMsgpackWireKeys(%s): MarshalMsgpack: got err == %s, want err == nil", test.name, err)
+			continue
+		}
+
+		var wire []any
+		if err := msgpack.Unmarshal(data, &wire); err != nil {
+			t.Errorf("TestMarshalMsgpackWireKeys(%s): msgpack.Unmarshal: got err == %s, want err == nil", test.name, err)
+			continue
+		}
+
+		if len(wire) != 3 {
+			t.Errorf("TestMarshalMsgpackWireKeys(%s): outer envelope length = %d, want 3", test.name, len(wire))
+			continue
+		}
+
+		outer, ok := wire[1].([]any)
+		if !ok || len(outer) != 1 {
+			t.Errorf("TestMarshalMsgpackWireKeys(%s): wire[1] = %T (len %d), want []any of length 1", test.name, wire[1], len(outer))
+			continue
+		}
+		inner, ok := outer[0].([]any)
+		if !ok || len(inner) != 2 {
+			t.Errorf("TestMarshalMsgpackWireKeys(%s): wire[1][0] = %T (len %d), want []any of length 2", test.name, outer[0], len(inner))
+			continue
+		}
+
+		body, ok := inner[1].(map[string]any)
+		if !ok {
+			t.Errorf("TestMarshalMsgpackWireKeys(%s): body type = %T, want map[string]any", test.name, inner[1])
+			continue
+		}
+
+		if v, _ := body[test.wireKey].(string); v != test.wireValue {
+			t.Errorf("TestMarshalMsgpackWireKeys(%s): body[%q] = %v, want %q", test.name, test.wireKey, body[test.wireKey], test.wireValue)
+		}
+		if _, ok := body["ServiceTreeID"]; ok {
+			t.Errorf("TestMarshalMsgpackWireKeys(%s): found unexpected ServiceTreeID key; wire must use %q", test.name, test.wireKey)
+		}
+	}
 }


### PR DESCRIPTION
This pull request introduces support for a required `ServiceTreeID` field across the audit logging client and message types, ensuring that all audit messages include a unique service identifier. The changes enforce validation, propagate the identifier through the codebase, and add comprehensive tests to guarantee correct serialization and validation.

**ServiceTreeID support and validation:**

* The `Client` struct and the `New` constructor now require a `serviceTreeID` (a Microsoft GUID) to be provided and stored. The constructor returns an error if the ID is not set, enforcing its presence at client creation. (`audit/audit.go`) [[1]](diffhunk://#diff-c80ca56cd48cb47591a2d6b3ec88312c91af6a3154b729700193ad5475ec250aL20-R20) [[2]](diffhunk://#diff-c80ca56cd48cb47591a2d6b3ec88312c91af6a3154b729700193ad5475ec250aR95-R96) [[3]](diffhunk://#diff-c80ca56cd48cb47591a2d6b3ec88312c91af6a3154b729700193ad5475ec250aL170-R176) [[4]](diffhunk://#diff-c80ca56cd48cb47591a2d6b3ec88312c91af6a3154b729700193ad5475ec250aR195)
* The `Send` method on `Client` automatically sets the `ServiceTreeID` on outgoing `ControlPlane` and `DataPlane` messages. (`audit/audit.go`)
* The `Record` struct now includes a `ServiceTreeID` field, which is required for validation. The `Validate` method enforces that this field is set, and tests are updated to cover this validation. (`audit/msgs/msgs.go`, `audit/msgs/msgs_test.go`) [[1]](diffhunk://#diff-b4af1691b4690cbf2b7a7a38bdb4c6662464eae3f9591a61dde6d4c959e1161eR520-R521) [[2]](diffhunk://#diff-b4af1691b4690cbf2b7a7a38bdb4c6662464eae3f9591a61dde6d4c959e1161eR596-R598) [[3]](diffhunk://#diff-da5906a38bfda76584727354c6f897b3d9b2d6d23388ca7d58a03faa9348a220R361-R372) [[4]](diffhunk://#diff-da5906a38bfda76584727354c6f897b3d9b2d6d23388ca7d58a03faa9348a220R624-R630)
* The `HeartbeatMsg` struct now includes a `ServiceTreeID` field, and the heartbeat message sent by the client includes this value. (`audit/msgs/heatbeat.go`, `audit/audit.go`) [[1]](diffhunk://#diff-b9ff8220a5876de4f5c68fe36b2e8e2c47101ff32af43c88fd98eff316660aacR6-R7) [[2]](diffhunk://#diff-c80ca56cd48cb47591a2d6b3ec88312c91af6a3154b729700193ad5475ec250aR321)

**Testing and serialization:**

* Unit tests are updated and extended to ensure that the `ServiceTreeID` is validated and correctly serialized with the expected wire keys (`env_ikey` for records, `AsmAuditServiceId` for heartbeats). A new test, `TestMarshalMsgpackWireKeys`, verifies the on-the-wire encoding to prevent struct-tag errors. (`audit/msgs/msgs_test.go`)

**Test and usage updates:**

* All test and example code that creates a `Client` is updated to provide a valid `serviceTreeID`. (`audit/audit.go`, `audit/internal/scenarios/scenarios_test.go`, `audit/audit_test.go`) [[1]](diffhunk://#diff-c80ca56cd48cb47591a2d6b3ec88312c91af6a3154b729700193ad5475ec250aR56) [[2]](diffhunk://#diff-b0fc0028216f2602771c7d66b835dc8b57d5ef4cc736b2aaa35f05edbfe34384L55-R55) [[3]](diffhunk://#diff-b0fc0028216f2602771c7d66b835dc8b57d5ef4cc736b2aaa35f05edbfe34384L95-R95) [[4]](diffhunk://#diff-fad90c48c57df4af61812cd1b2e2a69e37a0726475f0235c09cd6dc47100e0ccL79-R82)